### PR TITLE
REMOVE Old fiware-node-logger library

### DIFF
--- a/lib/iotagent-thinking-things.js
+++ b/lib/iotagent-thinking-things.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var logger = require('fiware-node-logger'),
+var logger = require('logops'),
     http = require('http'),
     express = require('express'),
     thinkingListener = require('./middlewares/thinkingListener'),

--- a/lib/middlewares/responseGenerator.js
+++ b/lib/middlewares/responseGenerator.js
@@ -26,7 +26,7 @@
 var config = require('../../config'),
     synchronousRequests = {},
     events = require('events'),
-    logger = require('fiware-node-logger'),
+    logger = require('logops'),
     context = {
         op: 'TTAgent.ResponseGenerator'
     },

--- a/lib/middlewares/thinkingListener.js
+++ b/lib/middlewares/thinkingListener.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var logger = require('fiware-node-logger'),
+var logger = require('logops'),
     _ = require('underscore'),
     thinkingParser = require('../services/thinkingParser'),
     responseGenerator = require('./responseGenerator').generateResponse,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "logops": "*",
-    "fiware-node-logger": "https://github.com/telefonicaid/fiware-node-logger/tarball/81fdcb213db99eb61acecfd293c45d3fa144cf36",
     "iotagent-node-lib": "0.8.2",
     "underscore": "*",
     "express": "*",


### PR DESCRIPTION
In order to use Logops, as the rest of the components.