### PR TITLE
FIX Duplicate attributes in Black Button calls

### DIFF
--- a/lib/middlewares/thinkingListener.js
+++ b/lib/middlewares/thinkingListener.js
@@ -43,29 +43,6 @@ function parseResponse(req, res, next) {
     });
 }
 
-/**
- * This middleware serves as a temporary patch to allow a Context Adapter to register as Context Provider for
- * certain attributes without removing them from the Context Broker. It should be removed in the future when the
- * Context Provider functionality in the Context Broker is revised.
- */
-function duplicateAttributes(req, res, next) {
-    var duplicatingAttributes = ['interaction_type', 'service_id'],
-        newValue;
-
-    if (req.deviceInformation.staticAttributes &&
-        !(req.compoundValues && req.compoundValues.length === 1 && req.compoundValues[0].value === 'P')) {
-        for (var i = 0; i < req.deviceInformation.staticAttributes.length; i++) {
-            if (duplicatingAttributes.indexOf(req.deviceInformation.staticAttributes[i].name) >= 0) {
-                newValue = _.clone(req.deviceInformation.staticAttributes[i]);
-                newValue.name = 'aux_' + newValue.name;
-                req.compoundValues.push(newValue);
-            }
-        }
-    }
-
-    next();
-}
-
 function updateValuesInCB(req, res, next) {
     iotAgentLib.update(req.entityId, req.type, '', req.compoundValues, req.deviceInformation, function(error) {
         if (error) {
@@ -306,7 +283,6 @@ function loadContextRoutes(router, newConfig) {
         getStoredDevice,
         extractDeviceInformation,
         retrieveConfiguration,
-        duplicateAttributes,
         updateValuesInCB,
         responseGenerator);
 }

--- a/lib/services/thinkingParser.js
+++ b/lib/services/thinkingParser.js
@@ -284,18 +284,6 @@ function blackButtonRequestSynchronous(fields, result, timestamp, callback) {
         type: 'string',
         metadatas: timestamp
     });
-    result.attributes.push({
-        name: 'aux_op_action',
-        value: fields[3],
-        type: 'string',
-        metadatas: timestamp
-    });
-    result.attributes.push({
-        name: 'aux_op_extra',
-        value: fields[4] || ' ',
-        type: 'string',
-        metadatas: timestamp
-    });
 
     callback(null, result);
 }
@@ -339,24 +327,6 @@ function blackButtonRequestCreation(fields, result, timestamp, callback) {
         type: 'string',
         metadatas: timestamp
     });
-    result.attributes.push({
-        name: 'aux_op_status',
-        value: constants.states.PENDING,
-        type: 'string',
-        metadatas: timestamp
-    });
-    result.attributes.push({
-        name: 'aux_op_action',
-        value: fields[3],
-        type: 'string',
-        metadatas: timestamp
-    });
-    result.attributes.push({
-        name: 'aux_op_extra',
-        value: fields[4] || ' ',
-        type: 'string',
-        metadatas: timestamp
-    });
 
     callback(null, result);
 }
@@ -374,13 +344,6 @@ function blackButtonRequestPolling(fields, result, timestamp, callback) {
         metadatas: timestamp
     });
 
-    result.attributes.push({
-        name: 'aux_last_operation',
-        value: result.operation,
-        type: 'string',
-        metadatas: timestamp
-    });
-
     callback(null, result);
 }
 
@@ -389,12 +352,6 @@ function blackButtonCloseRequest(fields, result, timestamp, callback) {
 
     result.attributes.push({
         name: 'op_status',
-        value: constants.states.CLOSED,
-        type: 'string',
-        metadatas: timestamp
-    });
-    result.attributes.push({
-        name: 'aux_op_status',
         value: constants.states.CLOSED,
         type: 'string',
         metadatas: timestamp

--- a/test/unit/contextRequests/blackButtonCloseRequest.json
+++ b/test/unit/contextRequests/blackButtonCloseRequest.json
@@ -11,11 +11,6 @@
           "type": "string"
         },
         {
-          "name": "aux_op_status",
-          "value": "X",
-          "type": "string"
-        },
-        {
           "name": "last_operation",
           "value": "X",
           "type": "string"

--- a/test/unit/contextRequests/blackButtonCreationRequest.json
+++ b/test/unit/contextRequests/blackButtonCreationRequest.json
@@ -34,21 +34,6 @@
           "name": "op_extra",
           "value": "1234",
           "type": "string"
-        },
-        {
-          "name": "aux_op_status",
-          "value": "P",
-          "type": "string"
-        },
-        {
-          "name": "aux_op_action",
-          "value": "1",
-          "type": "string"
-        },
-        {
-          "name": "aux_op_extra",
-          "value": "1234",
-          "type": "string"
         }
       ]
     }

--- a/test/unit/contextRequests/blackButtonPollingRequestUpdate.json
+++ b/test/unit/contextRequests/blackButtonPollingRequestUpdate.json
@@ -9,11 +9,6 @@
           "name": "last_operation",
           "value": "P",
           "type": "string"
-        },
-        {
-          "name": "aux_last_operation",
-          "value": "P",
-          "type": "string"
         }
       ]
     }

--- a/test/unit/contextRequests/blackButtonSynchronousRequest.json
+++ b/test/unit/contextRequests/blackButtonSynchronousRequest.json
@@ -26,26 +26,6 @@
           "type": "string"
         },
         {
-          "name": "aux_op_action",
-          "value": "6",
-          "type": "string"
-        },
-        {
-          "name": "aux_op_extra",
-          "value": "FFE876AE",
-          "type": "string"
-        },
-        {
-          "name": "aux_interaction_type",
-          "type": "string",
-          "value": "synchronous"
-        },
-        {
-          "name": "aux_service_id",
-          "type": "string",
-          "value": "smartcity"
-        },
-        {
           "name": "interaction_type",
           "type": "string",
           "value": "synchronous"

--- a/test/unit/contextRequests/blackButtonSynchronousRequestWithoutExtra.json
+++ b/test/unit/contextRequests/blackButtonSynchronousRequestWithoutExtra.json
@@ -26,26 +26,6 @@
           "type": "string"
         },
         {
-          "name": "aux_op_action",
-          "value": "6",
-          "type": "string"
-        },
-        {
-          "name": "aux_op_extra",
-          "value": " ",
-          "type": "string"
-        },
-        {
-          "name": "aux_interaction_type",
-          "type": "string",
-          "value": "synchronous"
-        },
-        {
-          "name": "aux_service_id",
-          "type": "string",
-          "value": "smartcity"
-        },
-        {
           "name": "interaction_type",
           "type": "string",
           "value": "synchronous"


### PR DESCRIPTION
Remove the duplicate attributes that were used in the interaction with the Context Broker in Black Button scenarios, as now it can be used with notifications.